### PR TITLE
 OpenTelemetry 완전 구현: campaign-service 및 serving-service 관측가능성 개선

### DIFF
--- a/otel-collector-project/CLAUDE.md
+++ b/otel-collector-project/CLAUDE.md
@@ -1,0 +1,130 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is an OpenTelemetry study project implementing a distributed microservices architecture with comprehensive observability. The project demonstrates two different OpenTelemetry implementation approaches across multiple Spring Boot services.
+
+**Technology Stack:**
+- Java 21
+- Spring Boot 3.5.4
+- Spring Cloud 2025.0.0
+
+## Architecture
+
+The system consists of 6 main components:
+
+1. **eureka-server** (port varies) - Service discovery registry
+2. **api-gateway** (port 80) - Spring Cloud Gateway routing requests to services
+3. **campaign-service** (port 8080) - Business service using pure OpenTelemetry SDK
+4. **serving-service** (port 8080) - Business service using Micrometer + OpenTelemetry bridge
+5. **user-service** (port varies) - Basic user management service
+6. **OpenTelemetry Infrastructure** - Collector, Tempo, and Grafana for observability
+
+
+## OpenTelemetry Implementation Approaches
+
+### Campaign Service - Pure OpenTelemetry
+- Uses `io.opentelemetry:opentelemetry-bom:1.32.0`
+- Direct OpenTelemetry SDK implementation
+- Spring Boot starter: `opentelemetry-spring-boot-starter:1.32.0`
+
+### Serving Service - Micrometer Bridge
+- Uses `io.micrometer:micrometer-tracing-bridge-otel`
+- Micrometer abstraction with OpenTelemetry backend
+- Additional log shipping via `opentelemetry-logback-appender:1.32.0`
+- Supports both OTLP and Prometheus metrics
+
+## Common Development Commands
+
+### Build and Run
+```bash
+# Build entire project
+./gradlew build
+
+# Run specific service
+./gradlew :campaign-service:bootRun
+./gradlew :serving-service:bootRun
+./gradlew :api-gateway:bootRun
+./gradlew :eureka-server:bootRun
+./gradlew :user-service:bootRun
+
+# Run all services (if configured)
+./gradlew bootRun
+```
+
+### Testing
+```bash
+# Run all tests
+./gradlew test
+
+# Run specific service tests
+./gradlew :campaign-service:test
+./gradlew :serving-service:test
+```
+
+### Infrastructure
+```bash
+# Start OpenTelemetry infrastructure (Collector, Tempo, Grafana)
+docker-compose up -d
+
+# Stop infrastructure
+docker-compose down
+```
+
+## Key Configuration Files
+
+### OpenTelemetry Collector
+- `collector-config.yaml` - OTLP receivers, tail sampling, exporters to Tempo
+- Receives data on ports 4317 (gRPC) and 4318 (HTTP)
+
+### Grafana Tempo
+- `tempo-config.yaml` - Trace storage backend configuration
+- UI available at http://localhost:3200
+
+### Service Configuration
+- Each service has `application.yml` with Eureka client and observability settings
+- Serving service includes `logback-spring.xml` for OTLP log shipping
+
+## Service Dependencies
+
+All services depend on:
+- Spring Boot 3.5.4
+- Spring Cloud 2025.0.0
+- Java 21
+- Eureka Client for service discovery
+- Spring Boot Actuator
+
+### Campaign Service Additional Dependencies
+- Pure OpenTelemetry SDK
+- Prometheus metrics registry
+
+### Serving Service Additional Dependencies  
+- Micrometer tracing bridge
+- OTLP metrics registry
+- OpenTelemetry Logback appender
+
+### API Gateway Additional Dependencies
+- Spring Cloud Gateway
+- Custom filters: CampaignAuthFilter, CampaignLoggingFilter
+
+## Monitoring Endpoints
+
+- Grafana UI: http://localhost:3000
+- Tempo UI: http://localhost:3200
+- Service metrics: http://localhost:8080/actuator/prometheus
+- Service health: http://localhost:8080/actuator/health
+
+## Data Flow
+
+1. Requests → API Gateway → Services
+2. Services generate traces/metrics/logs → OpenTelemetry Collector (port 4317/4318)
+3. Collector processes and exports → Tempo (traces) and file outputs
+4. Grafana queries Tempo for trace visualization
+
+## Service Routing (API Gateway)
+
+- `/api/campaign/**` → campaign-service (with auth/logging filters)
+- `/api/serving/**` → serving-service (with path rewriting)
+- `/api/user/**` → user-service (with path rewriting)

--- a/otel-collector-project/api-gateway/readme.md
+++ b/otel-collector-project/api-gateway/readme.md
@@ -1,0 +1,64 @@
+# API Gateway 모듈
+
+## 개요
+OpenTelemetry 스터디 프로젝트의 API Gateway 모듈입니다. Spring Cloud Gateway를 사용하여 마이크로서비스 아키텍처에서 중앙 집중식 API 관리 역할을 담당합니다.
+
+## 주요 기능
+- **라우팅**: 클라이언트 요청을 적절한 마이크로서비스로 라우팅
+- **로드 밸런싱**: Eureka 서비스 디스커버리를 통한 서비스 인스턴스 로드 밸런싱
+- **분산 추적**: OpenTelemetry를 활용한 요청 추적 및 모니터링
+- **필터링**: 인증, 로깅 등의 횡단 관심사 처리
+
+## 기술 스택
+- **Spring Cloud Gateway**: API 게이트웨이 프레임워크
+- **Spring WebFlux**: 리액티브 웹 스택
+- **Eureka Client**: 서비스 디스커버리 클라이언트
+- **OpenTelemetry**: 분산 추적 및 모니터링
+- **Micrometer**: 메트릭 수집
+
+## 라우팅 구성
+
+### Campaign Service
+- **경로**: `/api/campaign/**`
+- **대상**: `lb://campaign-service:8080`
+- **필터**: CampaignAuthFilter, CampaignLoggingFilter
+
+### Serving Service
+- **경로**: `/api/serving/**`
+- **대상**: `lb://serving-service`
+- **필터**: RewritePath (경로 재작성)
+
+### User Service
+- **경로**: `/api/user/**`
+- **대상**: `lb://user-service`
+- **필터**: RewritePath (경로 재작성)
+
+## 의존성
+```gradle
+implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
+implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+implementation 'io.micrometer:micrometer-tracing-bridge-otel' // 분산 추적
+runtimeOnly 'io.micrometer:micrometer-registry-otlp' // 메트릭 전송
+```
+
+## 실행 환경
+- **포트**: 80
+- **프로필**: Spring Boot 기본 프로필
+- **로깅**: Spring Cloud Gateway 및 HTTP 요청/응답 정보 DEBUG 레벨
+
+## 실행 방법
+```bash
+./gradlew bootRun
+```
+
+## 필터 구성
+- **CampaignAuthFilter**: Campaign 서비스 요청에 대한 인증 처리
+- **CampaignLoggingFilter**: Campaign 서비스 요청에 대한 로깅 처리
+- **AddRequestHeader**: 모든 요청에 X-Request-Foo 헤더 추가
+- **AddResponseHeader**: 모든 응답에 X-Response-Foo 헤더 추가
+
+## 분산 추적
+OpenTelemetry와 Micrometer를 통해 요청의 분산 추적이 가능합니다:
+- 트레이스 ID와 스팬 ID 자동 생성
+- MDC(Mapped Diagnostic Context)를 통한 로그 연동
+- OTLP 프로토콜을 통한 수집기로 데이터 전송

--- a/otel-collector-project/campaign-service/README.md
+++ b/otel-collector-project/campaign-service/README.md
@@ -1,0 +1,153 @@
+# Campaign Service - Pure OpenTelemetry Implementation
+
+이 서비스는 **순수 OpenTelemetry SDK** 방식을 사용한 관측 가능성 구현을 보여줍니다.
+
+## 구현 방식
+
+### Technology Stack
+- **OpenTelemetry SDK**: `io.opentelemetry:opentelemetry-bom:1.32.0`
+- **Micrometer Bridge**: `io.micrometer:micrometer-tracing-bridge-otel`
+- **OTLP Exporter**: `io.opentelemetry:opentelemetry-exporter-otlp`
+
+### Key Dependencies
+```gradle
+// Micrometer OpenTelemetry 브릿지 방식
+implementation 'io.micrometer:micrometer-tracing-bridge-otel'
+implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
+
+// Prometheus 메트릭 (Actuator)
+runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+```
+
+## OpenTelemetry 설정
+
+### Bean Configuration
+```java
+@Configuration
+public class OpenTelemetryConfig {
+    @Bean
+    public Tracer tracer() {
+        return GlobalOpenTelemetry.getTracer("campaign-service");
+    }
+
+    @Bean  
+    public Meter meter() {
+        return GlobalOpenTelemetry.getMeter("campaign-service");
+    }
+}
+```
+
+### Application Configuration
+```yaml
+management:
+  otlp:
+    tracing:
+      endpoint: http://localhost:4318  # HTTP endpoint
+    metrics:
+      export:
+        enabled: true
+        url: http://localhost:4318/v1/metrics
+        step: 10s
+  tracing:
+    sampling:
+      probability: 1.0
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+
+logging:
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss.SSS} %clr(%-5level) %clr([${spring.application.name:-}]){yellow} %clr([%15.15t]){faint} %clr([%X{traceId:-},%X{spanId:-}]){magenta} %clr(%-40.40logger{39}){cyan} : %msg%n"
+```
+
+## 트레이싱 구현 예제
+
+### 1. 수동 트레이싱 (Manual Instrumentation)
+```java
+@GetMapping("/api/campaign/create")
+public String campaignCreate() {
+    // 수동 스팬 생성
+    Span span = tracer.spanBuilder("campaign_create")
+        .setSpanKind(SpanKind.SERVER)
+        .startSpan();
+
+    try (Scope scope = span.makeCurrent()) {
+        // 스팬 속성 추가
+        span.setAttribute("campaign.operation", "create");
+        span.setAttribute("http.method", "GET");
+        
+        // 메트릭 카운터 증가
+        campaignCreateCounter.add(1);
+        
+        // 비즈니스 로직...
+        return "success";
+    } catch (Exception e) {
+        span.recordException(e);
+        span.setStatus(StatusCode.ERROR, e.getMessage());
+        throw new RuntimeException(e);
+    } finally {
+        span.end();
+    }
+}
+```
+
+### 2. 자동 트레이싱 (Auto Instrumentation)
+```java
+@GetMapping("/api/campaign/list")
+public String campaignList() throws InterruptedException {
+    // Spring Boot가 자동으로 HTTP 요청을 트레이싱
+    log.info("Fetching campaign list");
+    Thread.sleep(30);
+    return "campaign-list-data";
+}
+```
+
+## serving-service와의 차이점
+
+| 특징 | campaign-service | serving-service |
+|------|------------------|-----------------|
+| **구현 방식** | 순수 OpenTelemetry SDK | Micrometer + OpenTelemetry Bridge |
+| **트레이싱** | 수동 스팬 생성 | 자동 계측 중심 |
+| **메트릭** | OpenTelemetry Meter | Micrometer 추상화 |
+| **설정 복잡도** | 높음 | 낮음 |
+| **제어 수준** | 세밀함 | 표준화됨 |
+
+## 장단점 비교
+
+### 장점
+- **완전한 제어**: 스팬 생성부터 속성까지 세밀하게 제어 가능
+- **OpenTelemetry 표준 준수**: 순수 OpenTelemetry 방식
+- **성능 최적화**: 필요한 부분만 계측 가능
+- **벤더 중립**: OpenTelemetry 표준을 완전히 따름
+
+### 단점  
+- **개발 복잡도 증가**: 수동으로 스팬을 관리해야 함
+- **실수 가능성**: 스팬을 제대로 닫지 않으면 메모리 누수 위험
+- **보일러플레이트 코드**: 반복적인 트레이싱 코드 필요
+
+## 사용 사례
+
+이 방식은 다음과 같은 경우에 적합합니다:
+
+1. **세밀한 제어가 필요한 경우**
+2. **복잡한 비즈니스 로직의 상세한 추적**
+3. **커스텀 메트릭과 속성이 많이 필요한 경우**
+4. **OpenTelemetry 표준을 완전히 준수해야 하는 경우**
+
+## 실행 방법
+
+```bash
+# 빌드 및 실행
+./gradlew :campaign-service:bootRun
+
+# 테스트 엔드포인트
+curl http://localhost:8080/api/campaign/create
+curl http://localhost:8080/api/campaign/list
+```
+
+## 모니터링 엔드포인트
+
+- **Prometheus 메트릭**: `http://localhost:8080/actuator/prometheus`
+- **Health Check**: `http://localhost:8080/actuator/health`
+- **사용자 정의 메트릭**: `campaign_create_requests_total`

--- a/otel-collector-project/campaign-service/build.gradle
+++ b/otel-collector-project/campaign-service/build.gradle
@@ -5,8 +5,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    //runtimeOnly 'io.micrometer:micrometer-registry-otlp'
+
+    // Micrometer OpenTelemetry 브릿지 방식
+    implementation 'io.micrometer:micrometer-tracing-bridge-otel'
+    implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
+
+
+    
+    // 기존 Prometheus는 유지 actuator 에서 사용
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+    
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/otel-collector-project/campaign-service/src/main/java/com/example/CampaignController.java
+++ b/otel-collector-project/campaign-service/src/main/java/com/example/CampaignController.java
@@ -1,20 +1,90 @@
 package com.example;
 
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.context.Scope;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Description
+ * 순수 OpenTelemetry를 사용한 Campaign Controller
+ * - 수동 트레이스 계측
+ * - 커스텀 메트릭 생성
+ * - 구조화된 로깅
  *
  * @author yohan.an
  * @version Copyright (C) 2025 by KakaoHealthcare. All right reserved.
  * @since 2025. 8. 6.
  */
+@Slf4j
 @RestController
 public class CampaignController {
 
+    private final Tracer tracer;
+    private final LongCounter campaignCreateCounter;
+
+    public CampaignController(Tracer tracer, Meter meter) {
+
+        this.tracer = tracer;
+        this.campaignCreateCounter = meter
+            .counterBuilder("campaign_create_requests_total")
+            .setDescription("Total number of campaign create requests")
+            .build();
+    }
+
+    /**
+     * 수동 트레이싱 예제 - 직접 스팬 생성/관리
+     */
     @GetMapping("/api/campaign/create")
     public String campaignCreate() {
-        return "success";
+        // 수동 스팬 생성
+        Span span = tracer.spanBuilder("campaign_create")
+            .setSpanKind(io.opentelemetry.api.trace.SpanKind.SERVER)
+            .startSpan();
+
+        try (Scope scope = span.makeCurrent()) {
+            // 스팬 속성 추가
+            span.setAttribute("campaign.operation", "create");
+            span.setAttribute("http.method", "GET");
+
+            // 메트릭 카운터 증가
+            campaignCreateCounter.add(1);
+
+            // 구조화된 로깅 (traceId, spanId 자동 포함)
+            log.info("Processing campaign creation request");
+
+            // 비즈니스 로직 시뮬레이션
+            Thread.sleep(50); // 50ms 지연
+
+            log.info("Campaign creation completed successfully");
+
+            return "success";
+        } catch (Exception e) {
+            // 에러 처리
+            span.recordException(e);
+            span.setStatus(io.opentelemetry.api.trace.StatusCode.ERROR, e.getMessage());
+            log.error("Campaign creation failed", e);
+            throw new RuntimeException(e);
+        } finally {
+            span.end();
+        }
+    }
+
+    /**
+     * Spring Boot 자동 트레이싱 예제 - 별도 어노테이션 없이 자동 계측
+     */
+    @GetMapping("/api/campaign/list")
+    public String campaignList() throws InterruptedException {
+        log.info("Fetching campaign list");
+        
+        // 비즈니스 로직 시뮬레이션
+        Thread.sleep(30);
+        
+        log.info("Campaign list retrieved successfully");
+        return "campaign-list-data";
     }
 }

--- a/otel-collector-project/campaign-service/src/main/java/com/example/OpenTelemetryConfig.java
+++ b/otel-collector-project/campaign-service/src/main/java/com/example/OpenTelemetryConfig.java
@@ -1,0 +1,21 @@
+package com.example;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.trace.Tracer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenTelemetryConfig {
+
+    @Bean
+    public Tracer tracer() {
+        return GlobalOpenTelemetry.getTracer("campaign-service");
+    }
+
+    @Bean
+    public Meter meter() {
+        return GlobalOpenTelemetry.getMeter("campaign-service");
+    }
+}

--- a/otel-collector-project/campaign-service/src/main/resources/application.yml
+++ b/otel-collector-project/campaign-service/src/main/resources/application.yml
@@ -5,8 +5,33 @@ spring:
   application:
     name: campaign-service
 
-
 eureka:
   client:
     serviceUrl:
       defaultZone: http://localhost:8761/eureka/
+
+
+# Micrometer Tracing & OTLP 설정
+management:
+  otlp:
+    tracing:
+      endpoint: http://localhost:4318  # HTTP endpoint
+    metrics:
+      export:
+        enabled: true
+        url: http://localhost:4318/v1/metrics
+        step: 10s
+  tracing:
+    sampling:
+      probability: 1.0
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+
+logging:
+  level:
+    root: info
+    com.example: debug
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss.SSS} %clr(%-5level) %clr([${spring.application.name:-}]){yellow} %clr([%15.15t]){faint} %clr([%X{traceId:-},%X{spanId:-}]){magenta} %clr(%-40.40logger{39}){cyan} : %msg%n"

--- a/otel-collector-project/campaign-service/src/main/resources/logback-spring.xml.back
+++ b/otel-collector-project/campaign-service/src/main/resources/logback-spring.xml.back
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- Console Appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %clr(%-5level) %clr([${spring.application.name:-}]){yellow} %clr([%15.15t]){faint} %clr([%X{traceId:-},%X{spanId:-}]){magenta} %clr(%-40.40logger{39}){cyan} : %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- OpenTelemetry OTLP Appender for logs -->
+    <appender name="OTLP" class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
+        <endpoint>http://localhost:4318/v1/logs</endpoint>
+        <captureExperimentalAttributes>true</captureExperimentalAttributes>
+        <captureCodeAttributes>true</captureCodeAttributes>
+        <captureMarkerAttribute>true</captureMarkerAttribute>
+        <captureKeyValuePairAttributes>true</captureKeyValuePairAttributes>
+        <includeInstrumentationScopeInfo>true</includeInstrumentationScopeInfo>
+    </appender>
+
+    <!-- Root Logger -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="OTLP"/>
+    </root>
+
+    <!-- Service specific logging -->
+    <logger name="com.example" level="DEBUG" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="OTLP"/>
+    </logger>
+</configuration>

--- a/otel-collector-project/collector-config.yaml
+++ b/otel-collector-project/collector-config.yaml
@@ -32,9 +32,27 @@ exporters:
     tls:
       insecure: true # 개발 환경에서 TLS 비활성화 (운영 시에는 구성 필요)
 
+  # 로그를 Loki로 전송
+  loki:
+    endpoint: http://loki:3100/loki/api/v1/push
+
+  # 파일로 출력 (테스트용)
+  file:
+    path: ./logs/otel-data.json
+
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [tail_sampling] # tail_sampling 프로세서 적용
       exporters: [otlp] # OTLP 익스포터를 통해 Tempo로 전송
+    
+    # 로그 파이프라인 추가
+    logs:
+      receivers: [otlp]
+      exporters: [loki, file] # Loki와 파일 모두로 전송
+    
+    # 메트릭 파이프라인 추가
+    metrics:
+      receivers: [otlp]
+      exporters: [file] # 일단 파일로 출력

--- a/otel-collector-project/collector-config.yaml
+++ b/otel-collector-project/collector-config.yaml
@@ -32,7 +32,6 @@ exporters:
     tls:
       insecure: true # 개발 환경에서 TLS 비활성화 (운영 시에는 구성 필요)
 
-# Service: 위에서 정의한 컴포넌트들을 연결하여 파이프라인 구성
 service:
   pipelines:
     traces:

--- a/otel-collector-project/serving-service/build.gradle
+++ b/otel-collector-project/serving-service/build.gradle
@@ -5,8 +5,9 @@ dependencies {
     implementation 'io.micrometer:micrometer-tracing-bridge-otel' // Tracing-Log 연동
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'io.micrometer:micrometer-registry-otlp' // 로그 전송
+    runtimeOnly 'io.micrometer:micrometer-registry-otlp'           // 매트릭 전송 전송
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.opentelemetry:opentelemetry-logback-appender:1.32.0' // 로그 전송
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/otel-collector-project/serving-service/build.gradle
+++ b/otel-collector-project/serving-service/build.gradle
@@ -5,9 +5,9 @@ dependencies {
     implementation 'io.micrometer:micrometer-tracing-bridge-otel' // Tracing-Log 연동
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'io.micrometer:micrometer-registry-otlp'           // 매트릭 전송 전송
+    runtimeOnly 'io.micrometer:micrometer-registry-otlp'           // 메트릭 전송
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
-    implementation 'io.opentelemetry:opentelemetry-logback-appender:1.32.0' // 로그 전송
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:2.19.0-alpha' // 로그 전송
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/otel-collector-project/serving-service/readme.md
+++ b/otel-collector-project/serving-service/readme.md
@@ -61,9 +61,23 @@ logging:
 ```xml
 <appender name="OTLP" class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
     <endpoint>http://localhost:4317</endpoint>
-    <includeMdc>true</includeMdc>
+    <captureExperimentalAttributes>true</captureExperimentalAttributes>
+    <captureKeyValuePairAttributes>true</captureKeyValuePairAttributes>
+    <captureLoggerContext>true</captureLoggerContext>
+    <captureMarkerAttribute>true</captureMarkerAttribute>
+    <captureMdcAttributes>true</captureMdcAttributes>
 </appender>
 ```
+
+#### ⚠️ 중요: gRPC 엔드포인트 설정
+OpenTelemetry에서 gRPC 연결시 스키마 사용법:
+- ✅ `http://localhost:4317` - insecure gRPC 연결 (올바름)
+- ✅ `https://localhost:4317` - secure gRPC 연결 (TLS)
+- ❌ `grpc://localhost:4317` - OpenTelemetry 표준에서 사용하지 않음
+
+**포트별 프로토콜**:
+- **4317**: gRPC (하지만 `http://` 스키마 사용)
+- **4318**: HTTP REST API
 
 ## 아키텍처 선택 배경
 

--- a/otel-collector-project/serving-service/readme.md
+++ b/otel-collector-project/serving-service/readme.md
@@ -1,0 +1,106 @@
+# Serving Service 모듈
+
+## 개요
+OpenTelemetry 스터디 프로젝트의 Serving Service 모듈입니다. Micrometer 기반의 관측 가능성(Observability) 구현을 통해 분산 추적, 메트릭 수집, 로그 전송 기능을 제공합니다.
+
+## 주요 기능
+- **분산 추적**: Micrometer를 통한 OpenTelemetry 트레이스 생성 및 전송
+- **메트릭 수집**: OTLP 및 Prometheus 형식의 메트릭 수집
+- **로그 전송**: OTLP 프로토콜을 통한 중앙 집중식 로그 관리
+- **서비스 디스커버리**: Eureka를 통한 마이크로서비스 등록 및 발견
+
+## 기술 스택
+- **Spring Boot**: 애플리케이션 프레임워크
+- **Spring Web**: RESTful API 제공
+- **Eureka Client**: 서비스 디스커버리 클라이언트
+- **Micrometer**: 메트릭 및 트레이싱 추상화 라이브러리
+- **OpenTelemetry**: 분산 추적 표준
+
+## 관측 가능성 구성
+
+### 1. 분산 추적
+```gradle
+implementation 'io.micrometer:micrometer-tracing-bridge-otel'
+```
+- Micrometer의 트레이싱 추상화를 OpenTelemetry 구현체로 연결
+- 자동 트레이스 ID 및 스팬 ID 생성
+- MDC(Mapped Diagnostic Context)를 통한 로그와 트레이스 연동
+
+### 2. 메트릭 수집
+```gradle
+runtimeOnly 'io.micrometer:micrometer-registry-otlp'      // OTLP 프로토콜 전송
+runtimeOnly 'io.micrometer:micrometer-registry-prometheus' // Prometheus 메트릭 노출
+```
+- **OTLP 방식**: Push 방식으로 OpenTelemetry Collector에 메트릭 전송
+- **Prometheus 방식**: Pull 방식으로 `/actuator/prometheus` 엔드포인트 노출
+
+### 3. 로그 전송
+```gradle
+implementation 'io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:2.19.0-alpha'
+```
+- OpenTelemetry Logback Appender를 통한 OTLP 로그 전송
+- `logback-spring.xml` 설정을 통한 콘솔과 OTLP 이중 출력
+- 트레이스 ID와 스팬 ID가 자동으로 로그에 포함
+- Micrometer와 OpenTelemetry 하이브리드 방식으로 완전한 관측 가능성 구현
+
+## 설정 구성
+
+### application.yml
+```yaml
+spring:
+  application:
+    name: serving-service
+
+logging:
+  level:
+    root: info
+    com.example: debug
+```
+
+### logback-spring.xml
+```xml
+<appender name="OTLP" class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
+    <endpoint>http://localhost:4317</endpoint>
+    <includeMdc>true</includeMdc>
+</appender>
+```
+
+## 아키텍처 선택 배경
+
+### Micrometer 기반 접근 방식 채택 이유
+1. **Spring Boot 생태계 통합**: Spring Actuator와의 자연스러운 연동
+2. **점진적 도입**: 기존 Spring 애플리케이션에 최소한의 변경으로 적용 가능
+3. **다중 백엔드 지원**: OTLP, Prometheus 등 여러 모니터링 시스템 동시 지원
+4. **안정성**: Spring 진영에서 검증된 메트릭 수집 방식
+
+### 순수 OpenTelemetry 대비 장단점
+
+#### 장점
+- Spring Boot 자동 설정 활용
+- 기존 Spring 메트릭과의 호환성
+- 설정 복잡도 감소
+
+#### 단점
+- 여러 라이브러리 조합으로 인한 복잡성
+- OpenTelemetry 표준 완전 준수 어려움
+- 로그 전송을 위한 별도 설정 필요
+
+## 데이터 흐름
+
+```리드 
+Serving Service
+    ├── 트레이스 → micrometer-tracing-bridge-otel → OTLP → OpenTelemetry Collector
+    ├── 메트릭 → micrometer-registry-otlp → OTLP → OpenTelemetry Collector
+    │         → micrometer-registry-prometheus → /actuator/prometheus → Prometheus
+    └── 로그 → opentelemetry-logback-appender → OTLP → OpenTelemetry Collector
+```
+
+## 실행 방법
+```bash
+./gradlew :serving-service:bootRun
+```
+
+## 모니터링 엔드포인트
+- **Prometheus 메트릭**: `http://localhost:8080/actuator/prometheus`
+- **Health Check**: `http://localhost:8080/actuator/health`
+- **Eureka 등록 정보**: Eureka Server에서 확인 가능

--- a/otel-collector-project/serving-service/src/main/resources/logback-spring.xml
+++ b/otel-collector-project/serving-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- 기본 콘솔 출력 설정 -->
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    
+    <!-- 콘솔 appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %clr(%-5level) %clr([${spring.application.name:-}]){yellow} %clr([%15.15t]){faint} %clr([%X{traceId:-},%X{spanId:-}]){magenta} %clr(%-40.40logger{39}){cyan} : %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- OpenTelemetry OTLP appender -->
+    <appender name="OTLP" class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
+        <endpoint>http://localhost:4317</endpoint>
+        <includeLoggerName>true</includeLoggerName>
+        <includeLoggerContext>true</includeLoggerContext>
+        <includeCallerData>false</includeCallerData>
+        <includeMdc>true</includeMdc>
+        <includeArguments>true</includeArguments>
+        <includeStackTrace>true</includeStackTrace>
+    </appender>
+
+    <!-- 루트 로거 설정 -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="OTLP"/>
+    </root>
+
+    <!-- 특정 패키지 로그 레벨 설정 -->
+    <logger name="com.example" level="DEBUG" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="OTLP"/>
+    </logger>
+</configuration>

--- a/otel-collector-project/serving-service/src/main/resources/logback-spring.xml
+++ b/otel-collector-project/serving-service/src/main/resources/logback-spring.xml
@@ -13,12 +13,11 @@
     <!-- OpenTelemetry OTLP appender -->
     <appender name="OTLP" class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
         <endpoint>http://localhost:4317</endpoint>
-        <includeLoggerName>true</includeLoggerName>
-        <includeLoggerContext>true</includeLoggerContext>
-        <includeCallerData>false</includeCallerData>
-        <includeMdc>true</includeMdc>
-        <includeArguments>true</includeArguments>
-        <includeStackTrace>true</includeStackTrace>
+        <captureExperimentalAttributes>true</captureExperimentalAttributes>
+        <captureKeyValuePairAttributes>true</captureKeyValuePairAttributes>
+        <captureLoggerContext>true</captureLoggerContext>
+        <captureMarkerAttribute>true</captureMarkerAttribute>
+        <captureMdcAttributes>true</captureMdcAttributes>
     </appender>
 
     <!-- 루트 로거 설정 -->


### PR DESCRIPTION
## Summary
  - campaign-service: 순수 OpenTelemetry SDK 구현 완료
  - serving-service: Micrometer + OpenTelemetry 브릿지 방식 완료
  - 두 가지 OpenTelemetry 구현 방식 비교 및 문서화
  - OpenTelemetry Collector 설정 개선 (logs/metrics 파이프라인 추가)

  ## Test plan
  - [ ] campaign-service 빌드 및 실행 확인
  - [ ] serving-service 빌드 및 실행 확인
  - [ ] OpenTelemetry Collector 로그/메트릭 수집 확인
  - [ ] Grafana/Tempo 트레이싱 시각화 확인
